### PR TITLE
fix: persist retry count on linked issue comments

### DIFF
--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -793,14 +793,12 @@ class TestWorkerAgent:
         result = agent._try_retry_pr(pr)
 
         assert result is False
-        agent.github.comment_pr.assert_any_call(
-            pr.number,
-            f"🔄 **Retry attempt failed ({agent.MAX_RETRIES}/{agent.MAX_RETRIES})**\n\n"
-            f"RETRY:{agent.MAX_RETRIES}\n\n"
-            "Error: Failed to prepare workspace: boom",
+        assert any(
+            f"{agent.RETRY_MARKER}:{agent.MAX_RETRIES}" in str(call)
+            for call in agent.github.comment_issue.call_args_list
         )
         agent.github.add_pr_label.assert_any_call(pr.number, agent.STATUS_FAILED)
-        agent.github.comment_issue.assert_called_once()
+        assert agent.github.comment_issue.call_count >= 1
 
     @patch("shared.git_operations.GitOperations")
     @patch("shared.llm_client.LLMClient")


### PR DESCRIPTION
## Summary\n- switch retry persistence from PR comments to linked Issue comments\n- use WORKER_RETRY:N marker as primary key\n- keep backward compatibility by reading legacy RETRY:N markers\n- stop retry safely when linked issue cannot be resolved\n- add/update worker tests for new persistence behavior\n\n## Verification\n- uv run pytest -q\n- uv run pytest tests/test_worker.py -q\n- uv run ruff check worker-agent/main.py tests/test_worker.py\n- uv run ruff format --check worker-agent/main.py tests/test_worker.py\n- uv run mypy worker-agent/main.py