### PR TITLE
feat: use worktree for per-issue worker implementation

### DIFF
--- a/shared/git_operations.py
+++ b/shared/git_operations.py
@@ -163,10 +163,20 @@ class GitOperations:
         self._run(["branch", "-D", branch_name], check=False)
         self._run(["push", "origin", "--delete", branch_name], check=False)
 
-    def worktree_add(self, path: Path, branch: str) -> GitResult:
+    def worktree_add(
+        self,
+        path: Path,
+        branch: str,
+        *,
+        create_branch: bool = False,
+        base_branch: str = "main",
+    ) -> GitResult:
         """Add a new worktree."""
         # Ensure path parent exists
         path.parent.mkdir(parents=True, exist_ok=True)
+        if create_branch:
+            # git worktree add -b <branch> <path> <base_branch>
+            return self._run(["worktree", "add", "-b", branch, str(path), base_branch])
         # git worktree add <path> <branch>
         return self._run(["worktree", "add", str(path), branch])
 

--- a/shared/workspace.py
+++ b/shared/workspace.py
@@ -38,7 +38,12 @@ class WorkspaceManager:
 
     @contextmanager
     def worktree(
-        self, branch: str, agent_id: str
+        self,
+        branch: str,
+        agent_id: str,
+        *,
+        create_branch: bool = False,
+        base_branch: str = "main",
     ) -> Generator[GitOperations, None, None]:
         """
         Context manager that provides an isolated worktree.
@@ -67,7 +72,12 @@ class WorkspaceManager:
             # If remove failed or it wasn't a worktree but a dir, force remove dir?
             # Git worktree remove should handle cleaning the entry.
 
-        result = self.main_git.worktree_add(worktree_path, branch)
+        result = self.main_git.worktree_add(
+            worktree_path,
+            branch,
+            create_branch=create_branch,
+            base_branch=base_branch,
+        )
         if not result.success:
             # Try pruning and retry - sometimes metadata gets stale
             logger.warning(
@@ -77,7 +87,12 @@ class WorkspaceManager:
 
             # If the branch is already checked out, we might need to detach or force.
             # But for now, let's assume standard behavior.
-            result = self.main_git.worktree_add(worktree_path, branch)
+            result = self.main_git.worktree_add(
+                worktree_path,
+                branch,
+                create_branch=create_branch,
+                base_branch=base_branch,
+            )
 
             if not result.success:
                 raise RuntimeError(f"Failed to create worktree: {result.error}")


### PR DESCRIPTION
## Summary\n- extend git worktree add to support creating issue branches from base branch\n- extend workspace manager to pass create-branch/base-branch options\n- run Worker issue implementation flow inside per-issue worktree\n- keep safe fallback to legacy workspace flow if worktree setup fails\n- run tests in the active worktree path during issue implementation\n\n## Verification\n- uv run pytest tests/test_workspace.py tests/test_worker.py -q\n- uv run ruff check shared/git_operations.py shared/workspace.py worker-agent/main.py tests/test_workspace.py tests/test_worker.py\n- uv run ruff format --check shared/git_operations.py shared/workspace.py worker-agent/main.py tests/test_workspace.py tests/test_worker.py\n- uv run mypy .\n- uv run pytest -q