### PR TITLE
feat: add planner escalation detection and spec regeneration loop

### DIFF
--- a/planner-agent/main.py
+++ b/planner-agent/main.py
@@ -7,7 +7,10 @@ GitHub issues for the Worker Agent to implement.
 
 import argparse
 import logging
+import re
 import sys
+import time
+from datetime import datetime
 from pathlib import Path
 
 # Add parent directory to path for shared imports
@@ -30,6 +33,9 @@ class PlannerAgent:
     """Interactive agent for creating specifications from stories."""
 
     STATUS_READY = "status:ready"
+    STATUS_ESCALATED = "status:escalated"
+    STATUS_FAILED = "status:failed"
+    MAX_ESCALATION_RETRIES = 3
 
     def __init__(self, repo: str, config_path: str | None = None):
         self.repo = repo
@@ -125,6 +131,170 @@ class PlannerAgent:
             return f"Issue #{issue_num} created: https://github.com/{self.repo}/issues/{issue_num}"
         return None
 
+    def run_once(self) -> bool:
+        """Process one escalated issue and return True if handled."""
+        return self._process_escalations(limit=1)
+
+    def run_daemon(self) -> None:
+        """Run escalation processing loop."""
+        logger.info(f"Starting Planner escalation loop for {self.repo}")
+        logger.info(f"Poll interval: {self.config.poll_interval}s")
+        while True:
+            try:
+                self._process_escalations(limit=20)
+                time.sleep(self.config.poll_interval)
+            except KeyboardInterrupt:
+                logger.info("Shutting down Planner loop")
+                break
+            except Exception as e:
+                logger.exception(f"Unexpected planner loop error: {e}")
+                time.sleep(60)
+
+    def _process_escalations(self, limit: int = 20) -> bool:
+        """
+        Detect escalations from comments and regenerate issue specification.
+
+        Returns True if at least one issue was processed.
+        """
+        issues = self.github.list_issues(state="open", limit=100)
+        processed = 0
+
+        for issue in issues:
+            if processed >= limit:
+                break
+            if self._try_process_escalated_issue(issue.number):
+                processed += 1
+
+        if processed:
+            logger.info(f"Processed {processed} escalated issue(s)")
+        return processed > 0
+
+    def _try_process_escalated_issue(self, issue_number: int) -> bool:
+        """Process a single escalated issue if a new escalation exists."""
+        issue = self.github.get_issue(issue_number)
+        if issue is None:
+            return False
+
+        comments = self.github.get_issue_comments(issue_number, limit=100)
+        escalation = self._latest_escalation(comments)
+        if escalation is None:
+            return False
+
+        retry_count, retry_ts = self._latest_planner_retry(comments)
+        escalation_ts = self._parse_timestamp(escalation.get("created_at"))
+        if (
+            retry_ts is not None
+            and escalation_ts is not None
+            and escalation_ts <= retry_ts
+        ):
+            return False
+
+        if self.STATUS_ESCALATED not in issue.labels:
+            self.github.add_label(issue.number, self.STATUS_ESCALATED)
+
+        if retry_count >= self.MAX_ESCALATION_RETRIES:
+            self.github.remove_label(issue.number, self.STATUS_ESCALATED)
+            self.github.add_label(issue.number, self.STATUS_FAILED)
+            self.github.comment_issue(
+                issue.number,
+                f"⚠️ Planner retry limit reached.\n\n"
+                f"PLANNER_RETRY:{retry_count}\n\n"
+                f"Issue marked as `{self.STATUS_FAILED}` for manual intervention.",
+            )
+            return True
+
+        feedback = self._collect_escalation_feedback(comments)
+        prompt = (
+            "Refine the following technical specification using the escalation feedback.\n\n"
+            "Return a complete revised specification in markdown.\n\n"
+            f"## Current Specification\n{issue.body}\n\n"
+            f"## Escalation Feedback\n{feedback}\n"
+        )
+        revised_spec = self._generate_spec(prompt)
+        if not revised_spec:
+            self.github.comment_issue(
+                issue.number,
+                "⚠️ Planner failed to regenerate specification automatically.",
+            )
+            return False
+
+        if not self.github.update_issue_body(issue.number, revised_spec):
+            self.github.comment_issue(
+                issue.number,
+                "⚠️ Planner generated a revised specification but failed to update the issue body.",
+            )
+            return False
+
+        new_retry = retry_count + 1
+        self.github.comment_issue(
+            issue.number,
+            f"✅ Planner updated the specification from escalation feedback.\n\n"
+            f"PLANNER_RETRY:{new_retry}\n\n"
+            f"Transitioning issue back to `{self.STATUS_READY}`.",
+        )
+        self.github.remove_label(issue.number, self.STATUS_ESCALATED)
+        self.github.remove_label(issue.number, self.STATUS_FAILED)
+        self.github.add_label(issue.number, self.STATUS_READY)
+        return True
+
+    def _latest_escalation(self, comments: list[dict]) -> dict | None:
+        """Return latest escalation comment if exists."""
+        latest: dict | None = None
+        latest_ts: datetime | None = None
+        pattern = re.compile(r"ESCALATION:(worker|reviewer)", re.IGNORECASE)
+
+        for comment in comments:
+            body = str(comment.get("body", ""))
+            if not pattern.search(body):
+                continue
+            ts = self._parse_timestamp(comment.get("created_at"))
+            if latest is None or (
+                ts is not None and (latest_ts is None or ts > latest_ts)
+            ):
+                latest = comment
+                latest_ts = ts
+        return latest
+
+    def _latest_planner_retry(
+        self, comments: list[dict]
+    ) -> tuple[int, datetime | None]:
+        """Return max retry count and timestamp of latest retry marker."""
+        max_retry = 0
+        latest_ts: datetime | None = None
+        pattern = re.compile(r"PLANNER_RETRY:(\d+)")
+
+        for comment in comments:
+            body = str(comment.get("body", ""))
+            match = pattern.search(body)
+            if not match:
+                continue
+            count = int(match.group(1))
+            max_retry = max(max_retry, count)
+            ts = self._parse_timestamp(comment.get("created_at"))
+            if ts is not None and (latest_ts is None or ts > latest_ts):
+                latest_ts = ts
+
+        return max_retry, latest_ts
+
+    def _collect_escalation_feedback(self, comments: list[dict]) -> str:
+        """Collect escalation comment bodies for planner input."""
+        pattern = re.compile(r"ESCALATION:(worker|reviewer)", re.IGNORECASE)
+        parts = []
+        for comment in comments:
+            body = str(comment.get("body", "")).strip()
+            if pattern.search(body):
+                parts.append(body)
+        return "\n\n---\n\n".join(parts[-5:]) if parts else "No escalation feedback."
+
+    def _parse_timestamp(self, ts: str | None) -> datetime | None:
+        """Parse GitHub timestamp safely."""
+        if not ts:
+            return None
+        try:
+            return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+
     def _get_multiline_input(self, prompt: str) -> str:
         """Get potentially multiline input from user."""
         print(f"{prompt} (press Enter twice to finish):")
@@ -197,6 +367,16 @@ def main() -> None:
         action="store_true",
         help="Enable debug logging",
     )
+    parser.add_argument(
+        "--once",
+        action="store_true",
+        help="Process one escalated issue and exit",
+    )
+    parser.add_argument(
+        "--daemon",
+        action="store_true",
+        help="Run planner escalation loop",
+    )
 
     args = parser.parse_args()
 
@@ -214,6 +394,11 @@ def main() -> None:
         else:
             print("Failed to create specification")
             sys.exit(1)
+    elif args.once:
+        handled = agent.run_once()
+        sys.exit(0 if handled else 1)
+    elif args.daemon:
+        agent.run_daemon()
     else:
         # Interactive mode
         agent.interactive_mode()

--- a/shared/github_client.py
+++ b/shared/github_client.py
@@ -182,6 +182,20 @@ class GitHubClient:
         result = self._run(args, check=False)
         return result.returncode == 0
 
+    def update_issue_body(self, issue_number: int, body: str) -> bool:
+        """Update issue body."""
+        args = [
+            "issue",
+            "edit",
+            str(issue_number),
+            "--repo",
+            self.repo,
+            "--body",
+            body,
+        ]
+        result = self._run(args, check=False)
+        return result.returncode == 0
+
     def get_issue_comments(self, issue_number: int, limit: int = 30) -> list[dict]:
         """Get comments on an issue."""
         args = [

--- a/tests/test_github_client.py
+++ b/tests/test_github_client.py
@@ -187,6 +187,15 @@ class TestGitHubClient:
         assert self.client.comment_issue(1, "message") is False
 
     @patch("subprocess.run")
+    def test_update_issue_body(self, mock_run):
+        """Test updating issue body."""
+        mock_run.return_value = MagicMock(returncode=0)
+        assert self.client.update_issue_body(1, "new body") is True
+
+        mock_run.return_value = MagicMock(returncode=1)
+        assert self.client.update_issue_body(1, "new body") is False
+
+    @patch("subprocess.run")
     def test_get_issue_comments_parses_valid_json(self, mock_run):
         """Test parsing multiple comments with mixed validity."""
         mock_run.return_value = MagicMock(


### PR DESCRIPTION
## Summary
- add planner escalation processing loop (`--once` and `--daemon`)
- detect `ESCALATION:worker|reviewer` comments and avoid reprocessing old events
- track retries with `PLANNER_RETRY:N` markers (max 3)
- regenerate issue spec from original body + escalation feedback
- update issue body and return label from `status:escalated` to `status:ready`
- mark `status:failed` when retry limit is reached
- add `GitHubClient.update_issue_body()` API
- add planner/github unit tests

## Verification
- uv run pytest tests/test_github_client.py tests/test_planner.py -q
- uv run ruff check planner-agent/main.py shared/github_client.py tests/test_planner.py tests/test_github_client.py
- uv run ruff format --check planner-agent/main.py shared/github_client.py tests/test_planner.py tests/test_github_client.py
- uv run mypy .
- uv run pytest -q
