### PR TITLE
feat: #11 phase2 - surface local tdd result and strengthen ci-failure labeling

### DIFF
--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -633,6 +633,11 @@ class TestWorkerAgent:
             "ci-failed" in str(call)
             for call in agent.github.add_pr_label.call_args_list
         )
+        # CI test/check failures should also return PR to changes-requested
+        assert any(
+            "changes-requested" in str(call)
+            for call in agent.github.add_pr_label.call_args_list
+        )
 
     @patch("time.sleep")
     @patch("subprocess.run")
@@ -740,6 +745,11 @@ class TestWorkerAgent:
         assert not any(
             "ci-failed" in str(call)
             for call in agent.github.add_pr_label.call_args_list
+        )
+        # Should comment local TDD result on PR
+        assert any(
+            "Local TDD validation passed" in str(call)
+            for call in agent.github.comment_pr.call_args_list
         )
 
     @patch("shared.git_operations.GitOperations")

--- a/worker-agent/main.py
+++ b/worker-agent/main.py
@@ -505,6 +505,14 @@ Closes #{issue.number}
                 # Extract PR number from URL
                 pr_number = int(pr_url.split("/")[-1])
 
+                self.github.comment_pr(
+                    pr_number,
+                    f"🧪 **Local TDD validation passed**\n\n"
+                    f"- Tests generated before implementation\n"
+                    f"- Local test attempts: {test_retry_count + 1}/{self.MAX_RETRIES}\n"
+                    f"- Waiting for CI verification",
+                )
+
                 # Wait for CI and handle failures with retry loop
                 logger.info(f"[{self.agent_id}] Waiting for CI to complete...")
                 ci_passed, ci_status = self._wait_for_ci(
@@ -601,8 +609,11 @@ Please analyze and fix the CI failures.
                             f"[{self.agent_id}] CI failed after {ci_retry_count} fix attempts"
                         )
 
-                        # Mark PR with ci-failed status
+                        # Mark PR for changes requested due to failed tests/checks
                         self.github.add_pr_label(pr_number, self.STATUS_CI_FAILED)
+                        self.github.add_pr_label(
+                            pr_number, self.STATUS_CHANGES_REQUESTED
+                        )
                         self.github.remove_pr_label(pr_number, self.STATUS_REVIEWING)
 
                         self.github.comment_pr(
@@ -1077,6 +1088,7 @@ Please analyze and fix the CI failures.
 
                     # Mark PR with ci-failed status
                     self.github.add_pr_label(pr.number, self.STATUS_CI_FAILED)
+                    self.github.add_pr_label(pr.number, self.STATUS_CHANGES_REQUESTED)
                     self.github.remove_pr_label(pr.number, self.STATUS_REVIEWING)
 
                     self.github.comment_pr(


### PR DESCRIPTION
## Summary
- post local TDD validation results to the PR immediately after opening it
- add `status:changes-requested` when CI fix loop exhausts retries in issue implementation flow
- add `status:changes-requested` when CI fix loop exhausts retries in PR retry flow
- extend worker tests to assert both behaviors

## Why
Issue #11 phase2 focuses on better handoff visibility and clearer review state when CI cannot be stabilized automatically.

## Verification
- uv run ruff format worker-agent/main.py tests/test_worker.py
- uv run ruff check worker-agent/main.py tests/test_worker.py
- uv run ruff format --check worker-agent/main.py tests/test_worker.py
- uv run mypy .
- uv run pytest -q


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test assertions to verify new PR labels and comment behaviors.

* **Chores**
  * Enhanced PR feedback system to include changes-requested labels alongside ci-failed labels when CI fails.
  * Added local TDD validation success comments to PRs after automatic processing.
  * Improved review flow labeling to better guide developers on required actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->