### PR TITLE
chore: add reviewer test/coverage guidance as future issue candidate

### DIFF
--- a/shared/llm_client.py
+++ b/shared/llm_client.py
@@ -275,7 +275,12 @@ Brief summary of the changes
 ## Instructions
 
 1. Review the code changes against the specification
-2. Identify issues and classify each by severity:
+2. Review BOTH production code and test code in the diff
+3. Validate test adequacy for changed behavior:
+   - Missing tests for new/changed logic should be reported
+   - Weak assertions or missing edge cases should be reported
+   - Coverage gaps around critical paths should be reported as at least MAJOR
+4. Identify issues and classify each by severity:
    - **CRITICAL**: Security vulnerabilities, data loss risks, crashes
    - **MAJOR**: Functional failures, performance problems
    - **MINOR**: Code style violations, refactoring recommendations


### PR DESCRIPTION
## Summary
- add explicit reviewer guidance to evaluate test code and coverage gaps in `review_code_with_severity`
- add unit test to verify that the review prompt includes test/coverage checks

## Positioning
This is intentionally prepared as a future issue candidate / incremental quality improvement, separated from the main #11 delivery line.

## Verification
- uv run ruff format shared/llm_client.py tests/test_llm_client.py
- uv run ruff check shared/llm_client.py tests/test_llm_client.py
- uv run ruff format --check shared/llm_client.py tests/test_llm_client.py
- uv run mypy .
- uv run pytest tests/test_llm_client.py -q
- uv run pytest -q
