### PR TITLE
feat: add PolicyClient with tag-based search and embedding abstraction

### DIFF
--- a/shared/policy_client.py
+++ b/shared/policy_client.py
@@ -1,0 +1,194 @@
+"""Policy Client: retrieves relevant policies for a task spec.
+
+Provides a layered search strategy:
+  Phase A (current): tag-based filtering via PolicyStore.query()
+  Phase B (future):  vector search via sqlite-vec + OpenAI embeddings
+  Phase C (future):  local embedding model drop-in
+
+The EmbeddingBackend abstraction allows backend swaps without changing
+PolicyClient's interface.
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+
+from shared.policy_store import STATUS_ACTIVE, STRENGTH_MEDIUM, Policy, PolicyStore
+
+logger = logging.getLogger(__name__)
+
+
+# ── Embedding backend abstraction ─────────────────────────────────────────────
+
+
+class EmbeddingBackend(ABC):
+    """Abstract embedding backend — swap implementations without changing client."""
+
+    @abstractmethod
+    def embed(self, text: str) -> list[float]:
+        """Return a float vector for *text*."""
+
+
+class OpenAIEmbeddingBackend(EmbeddingBackend):
+    """
+    OpenAI text-embedding-3-small backend (Phase B).
+
+    Requires: pip install openai
+    Usage:
+        backend = OpenAIEmbeddingBackend(api_key="sk-...")
+        client  = PolicyClient(store, embedding_backend=backend)
+    """
+
+    MODEL = "text-embedding-3-small"
+
+    def __init__(self, api_key: str | None = None):
+        try:
+            import openai
+
+            self._client = openai.OpenAI(api_key=api_key)
+        except ImportError as e:
+            raise ImportError(
+                "openai package is required for OpenAIEmbeddingBackend. "
+                "Install with: pip install openai"
+            ) from e
+
+    def embed(self, text: str) -> list[float]:
+        response = self._client.embeddings.create(input=text, model=self.MODEL)
+        return list(response.data[0].embedding)
+
+
+# ── PolicyClient ──────────────────────────────────────────────────────────────
+
+
+def _policy_embed_text(policy: Policy) -> str:
+    """Build the text to embed for a policy — title + why + rules."""
+    rules_text = " ".join(policy.rules)
+    return f"{policy.title}. {policy.why}. {rules_text}"
+
+
+class PolicyClient:
+    """
+    High-level interface for fetching policies relevant to a task spec.
+
+    Search strategy (falls back gracefully):
+    1. Tag filter  — always available, zero extra dependencies
+    2. Vector search — used when sqlite-vec is loaded AND an EmbeddingBackend
+                       is provided; returns top-N by cosine similarity
+
+    Args:
+        store:             PolicyStore instance (caller owns lifecycle).
+        embedding_backend: Optional EmbeddingBackend for vector search.
+                           If None, tag-based search only.
+        min_strength:      Minimum policy strength to include
+                           (default: "medium").
+    """
+
+    def __init__(
+        self,
+        store: PolicyStore,
+        embedding_backend: EmbeddingBackend | None = None,
+        min_strength: str = STRENGTH_MEDIUM,
+    ) -> None:
+        self._store = store
+        self._embedding_backend = embedding_backend
+        self._min_strength = min_strength
+
+    # ── Public API ────────────────────────────────────────────────────────────
+
+    def get_policies_for_task(
+        self,
+        task_spec: str,
+        tags: list[str] | None = None,
+        limit: int = 5,
+    ) -> list[Policy]:
+        """
+        Return up to *limit* active policies relevant to *task_spec*.
+
+        Search order:
+        1. If an EmbeddingBackend is set and the store has vec support:
+           vector search (top-20) → strength filter → trim to limit
+        2. Otherwise: tag-based filter → trim to limit
+
+        Args:
+            task_spec: The task/spec text to search against.
+            tags:      Optional list of trigger tags to narrow results.
+            limit:     Maximum policies to return (default 5).
+
+        Returns:
+            List of Policy objects ordered by relevance.
+        """
+        if self._embedding_backend is not None and self._store._vec_enabled:
+            return self._vector_search(task_spec, tags=tags, limit=limit)
+        return self._tag_search(tags=tags, limit=limit)
+
+    # ── Search strategies ─────────────────────────────────────────────────────
+
+    def _tag_search(
+        self,
+        tags: list[str] | None = None,
+        limit: int = 5,
+    ) -> list[Policy]:
+        """Phase A: pure tag + strength filter via PolicyStore.query()."""
+        results = self._store.query(
+            status=STATUS_ACTIVE,
+            strength=self._min_strength,
+            tags=tags,
+            limit=limit,
+        )
+        logger.debug(f"tag_search returned {len(results)} policies (tags={tags})")
+        return results
+
+    def _vector_search(
+        self,
+        task_spec: str,
+        tags: list[str] | None = None,
+        limit: int = 5,
+    ) -> list[Policy]:
+        """
+        Phase B: embed task_spec → sqlite-vec cosine search → strength filter.
+
+        Falls back to tag search if embedding fails.
+        """
+        try:
+            task_vec = self._embedding_backend.embed(task_spec)  # type: ignore[union-attr]
+        except Exception as e:
+            logger.warning(f"Embedding failed, falling back to tag search: {e}")
+            return self._tag_search(tags=tags, limit=limit)
+
+        try:
+            import json
+
+            vec_blob = json.dumps(task_vec)
+            rows = self._store._conn.execute(
+                """
+                SELECT p.* FROM policies p
+                JOIN policies_vec v ON p.id = v.id
+                WHERE p.status = ?
+                ORDER BY vec_distance_cosine(v.embedding, ?)
+                LIMIT 20
+                """,
+                (STATUS_ACTIVE, vec_blob),
+            ).fetchall()
+        except Exception as e:
+            logger.warning(f"Vector search failed, falling back to tag search: {e}")
+            return self._tag_search(tags=tags, limit=limit)
+
+        policies = [self._store._row_to_policy(r) for r in rows]
+
+        # Apply strength filter
+        from shared.policy_store import _STRENGTH_ORDER
+
+        min_order = _STRENGTH_ORDER.get(self._min_strength, 0)
+        policies = [
+            p for p in policies if _STRENGTH_ORDER.get(p.strength, 0) >= min_order
+        ]
+
+        # Apply tag filter
+        if tags:
+            tag_set = set(tags)
+            policies = [p for p in policies if tag_set & set(p.trigger_tags)]
+
+        result = policies[:limit]
+        logger.debug(f"vector_search returned {len(result)} policies")
+        return result

--- a/tests/test_policy_client.py
+++ b/tests/test_policy_client.py
@@ -1,0 +1,214 @@
+"""Tests for shared/policy_client.py."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from shared.policy_client import EmbeddingBackend, OpenAIEmbeddingBackend, PolicyClient
+from shared.policy_store import (
+    STRENGTH_HIGH,
+    STRENGTH_LOW,
+    STRENGTH_MEDIUM,
+    Policy,
+    PolicyStore,
+)
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def store(tmp_path) -> PolicyStore:
+    db = PolicyStore(str(tmp_path / "test_policies.db"))
+    yield db
+    db.close()
+
+
+@pytest.fixture
+def client(store: PolicyStore) -> PolicyClient:
+    return PolicyClient(store)
+
+
+def _insert_active(
+    store: PolicyStore,
+    title: str = "Policy",
+    strength: str = STRENGTH_MEDIUM,
+    tags: list[str] | None = None,
+) -> str:
+    pid = store.insert_candidate(
+        {
+            "title": title,
+            "why": "Because it matters",
+            "rules": ["Do the thing"],
+            "strength": strength,
+            "trigger_tags": tags or ["bugfix"],
+            "trigger_conditions": [],
+        }
+    )
+    store.approve(pid)
+    return pid
+
+
+# ── EmbeddingBackend ABC ──────────────────────────────────────────────────────
+
+
+class TestEmbeddingBackendABC:
+    def test_cannot_instantiate_abstract_class(self) -> None:
+        with pytest.raises(TypeError):
+            EmbeddingBackend()  # type: ignore[abstract]
+
+    def test_concrete_subclass_must_implement_embed(self) -> None:
+        class NoEmbed(EmbeddingBackend):
+            pass
+
+        with pytest.raises(TypeError):
+            NoEmbed()  # type: ignore[abstract]
+
+    def test_valid_concrete_subclass(self) -> None:
+        class MockBackend(EmbeddingBackend):
+            def embed(self, text: str) -> list[float]:
+                return [0.1, 0.2, 0.3]
+
+        backend = MockBackend()
+        assert backend.embed("hello") == [0.1, 0.2, 0.3]
+
+
+# ── OpenAIEmbeddingBackend ────────────────────────────────────────────────────
+
+
+class TestOpenAIEmbeddingBackend:
+    def test_raises_import_error_if_openai_missing(self, monkeypatch) -> None:
+        import builtins
+
+        real_import = builtins.__import__
+
+        def mock_import(name, *args, **kwargs):
+            if name == "openai":
+                raise ImportError("No module named 'openai'")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", mock_import)
+        with pytest.raises(ImportError, match="openai package is required"):
+            OpenAIEmbeddingBackend()
+
+
+# ── PolicyClient: tag search (Phase A) ───────────────────────────────────────
+
+
+class TestPolicyClientTagSearch:
+    def test_returns_empty_for_empty_store(self, client: PolicyClient) -> None:
+        assert client.get_policies_for_task("some spec") == []
+
+    def test_returns_active_policies(
+        self, store: PolicyStore, client: PolicyClient
+    ) -> None:
+        pid = _insert_active(store)
+        results = client.get_policies_for_task("spec text")
+        assert any(p.id == pid for p in results)
+
+    def test_draft_not_returned(self, store: PolicyStore, client: PolicyClient) -> None:
+        store.insert_candidate(
+            {
+                "title": "Draft policy",
+                "why": "reason",
+                "rules": ["rule"],
+                "strength": STRENGTH_MEDIUM,
+                "trigger_tags": ["bugfix"],
+                "trigger_conditions": [],
+            }
+        )
+        assert client.get_policies_for_task("spec") == []
+
+    def test_tag_filter_applied(self, store: PolicyStore, client: PolicyClient) -> None:
+        bugfix_id = _insert_active(store, title="Bugfix policy", tags=["bugfix"])
+        refactor_id = _insert_active(store, title="Refactor policy", tags=["refactor"])
+
+        results = client.get_policies_for_task("spec", tags=["bugfix"])
+        ids = [p.id for p in results]
+        assert bugfix_id in ids
+        assert refactor_id not in ids
+
+    def test_strength_filter_excludes_low(
+        self, store: PolicyStore, client: PolicyClient
+    ) -> None:
+        low_id = _insert_active(store, title="Low", strength=STRENGTH_LOW)
+        high_id = _insert_active(store, title="High", strength=STRENGTH_HIGH)
+
+        results = client.get_policies_for_task("spec")
+        ids = [p.id for p in results]
+        assert high_id in ids
+        assert low_id not in ids
+
+    def test_limit_respected(self, store: PolicyStore, client: PolicyClient) -> None:
+        for i in range(10):
+            _insert_active(store, title=f"Policy {i}")
+
+        results = client.get_policies_for_task("spec", limit=3)
+        assert len(results) == 3
+
+    def test_returns_policy_objects(
+        self, store: PolicyStore, client: PolicyClient
+    ) -> None:
+        _insert_active(store)
+        results = client.get_policies_for_task("spec")
+        assert all(isinstance(p, Policy) for p in results)
+
+
+# ── PolicyClient: min_strength configuration ─────────────────────────────────
+
+
+class TestPolicyClientMinStrength:
+    def test_custom_min_strength_low_includes_all(self, store: PolicyStore) -> None:
+        client = PolicyClient(store, min_strength=STRENGTH_LOW)
+        low_id = _insert_active(store, title="Low", strength=STRENGTH_LOW)
+        results = client.get_policies_for_task("spec")
+        assert any(p.id == low_id for p in results)
+
+    def test_custom_min_strength_high_excludes_medium(self, store: PolicyStore) -> None:
+        client = PolicyClient(store, min_strength=STRENGTH_HIGH)
+        medium_id = _insert_active(store, title="Medium", strength=STRENGTH_MEDIUM)
+        high_id = _insert_active(store, title="High", strength=STRENGTH_HIGH)
+
+        results = client.get_policies_for_task("spec")
+        ids = [p.id for p in results]
+        assert high_id in ids
+        assert medium_id not in ids
+
+
+# ── PolicyClient: vector search fallback ─────────────────────────────────────
+
+
+class TestPolicyClientVectorFallback:
+    def test_falls_back_to_tag_search_when_embed_raises(
+        self, store: PolicyStore
+    ) -> None:
+        backend = MagicMock(spec=EmbeddingBackend)
+        backend.embed.side_effect = RuntimeError("embed failed")
+
+        # Force _vec_enabled True so vector path is attempted
+        store._vec_enabled = True
+        client = PolicyClient(store, embedding_backend=backend)
+
+        pid = _insert_active(store)
+        results = client.get_policies_for_task("spec", tags=["bugfix"])
+        # Fallback to tag search should still find the policy
+        assert any(p.id == pid for p in results)
+
+    def test_uses_tag_search_when_no_backend(
+        self, store: PolicyStore, client: PolicyClient
+    ) -> None:
+        # No embedding backend → always tag search regardless of vec_enabled
+        store._vec_enabled = True
+        pid = _insert_active(store, tags=["bugfix"])
+        results = client.get_policies_for_task("spec", tags=["bugfix"])
+        assert any(p.id == pid for p in results)
+
+    def test_uses_tag_search_when_vec_disabled(self, store: PolicyStore) -> None:
+        backend = MagicMock(spec=EmbeddingBackend)
+        store._vec_enabled = False
+        client = PolicyClient(store, embedding_backend=backend)
+
+        pid = _insert_active(store, tags=["bugfix"])
+        results = client.get_policies_for_task("spec", tags=["bugfix"])
+        # embed() should NOT have been called
+        backend.embed.assert_not_called()
+        assert any(p.id == pid for p in results)


### PR DESCRIPTION
## Summary

- `shared/policy_client.py`: high-level interface for fetching policies relevant to a task spec
- `EmbeddingBackend` ABC for swappable embedding backends
- `OpenAIEmbeddingBackend` (Phase B stub, graceful ImportError if openai not installed)
- `PolicyClient.get_policies_for_task()`: tag + strength filter (Phase A), vector search path (Phase B) with automatic fallback on failure or missing sqlite-vec

## Test plan

- [x] 16 pytest tests — all passing
- [x] EmbeddingBackend ABC: cannot instantiate abstract, concrete subclass works
- [x] OpenAIEmbeddingBackend: ImportError when openai not installed
- [x] Tag search: empty store, active policies returned, draft excluded, tag filter, strength filter, limit
- [x] min_strength configuration: low includes all, high excludes medium
- [x] Vector fallback: falls back to tag search when embed() raises, no embed call when vec disabled

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)